### PR TITLE
Support dark mode

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -196,7 +196,6 @@
 		.box {
 			padding-top: 5px !important;
 			margin: 0 !important;
-			background-color: #fff; /*#acd8fa*/
 		}
 
 		#log {


### PR DESCRIPTION
Remove background color of the adapter settings page to actually make it useable in dark mode.